### PR TITLE
fixed missing baseURL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/"
+baseURL = "https://deliveryconf.com/"
 languageCode = "en-us"
 DefaultContentLanguage = "en"
 title = "DeliveryConf"


### PR DESCRIPTION
Missing baseURL was causing links like /format and /sponsor to fail. 